### PR TITLE
Replace `Info` tabs with code annotations in the Snake tutorial

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ extra:
       name: Company profile on LinkedIn
 markdown_extensions:
   - admonition
+  - attr_list
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji

--- a/tutorials/snake/steps/step-2.md
+++ b/tutorials/snake/steps/step-2.md
@@ -10,47 +10,38 @@ Let's define that grid. There are different ways to define a grid. We could use 
 
 === "EDN"
 
-    ??? info inline end
-        The [`def`](https://docs.fragcolor.xyz/functions/macros/#def) keyword associates a value with a name.
-
-        `[]` is the syntax to define a sequence of values.
-
-    ```clojure linenums="1"
-    (def grid-cols 5)
+    ```{.clojure .annotate linenums="1"}
+    (def grid-cols 5) ;; (1)
     (def grid-rows 4)
     (def empty-grid
       [0 0 0 0 0
        0 0 0 0 0
        0 0 0 0 0
-       0 0 0 0 0])
+       0 0 0 0 0]) ;; (2)
     ```
+
+    1. The [`def`](https://docs.fragcolor.xyz/functions/macros/#def) keyword associates a value with a name.
+    2. `[]` is the syntax to define a sequence of values.
 
 Then to compute the index in that sequence from a set of 2D coordinates, we can define the following function.
 
 === "EDN"
 
-    ??? info inline end
-        The [`defn`](https://docs.fragcolor.xyz/functions/macros/#defn) keyword associates a function with a name. Note the `[]` after the `get-index` name. This indicates that this function has 0 parameters. We will see later functions which do have parameters.
-
-        `(->)` is a block container that will executes its inner block(s) in order.
-
-        `(|)` is an alias for [`(Sub)`](https://docs.fragcolor.xyz/blocks/General/Sub/). It allows to reuse the same input in the next block.
-
-        [`(Take)`](https://docs.fragcolor.xyz/blocks/General/Take/) returns the value from a sequence at a given index (starting at `0`).
-
-        `>=` saves the output of a block into a context variable.
-
-        [`(Math.Multiply)`](https://docs.fragcolor.xyz/blocks/Math/Multiply/) multiplies its input with a given value and outputs the result.
-
-        [`(Math.Add)`](https://docs.fragcolor.xyz/blocks/Math/Add/) adds a value to its input and outputs the result.
-
-    ```clojure linenums="1"
-    (defn get-index []
-      (-> (| (Take 0) >= .x)
-          (| (Take 1) >= .y)
-          .y (Math.Multiply grid-cols) (Math.Add .x)))
+    ```{.clojure .annotate linenums="1"}
+    (defn get-index [] ;; (1)
+      (-> (| (Take 0) >= .x) ;; (2) (3)
+          (| (Take 1) >= .y) ;; (4) (5)
+          .y (Math.Multiply grid-cols) (Math.Add .x))) ;; (6) (7)
     ```
 
+    1. The [`defn`](https://docs.fragcolor.xyz/functions/macros/#defn) keyword associates a function with a name. Note the `[]` after the `get-index` name. This indicates that this function has 0 parameters. We will see later functions which do have parameters.
+    2. `(->)` is a block container that will executes its inner block(s) in order.
+    3. `(|)` is an alias for [`(Sub)`](https://docs.fragcolor.xyz/blocks/General/Sub/). It allows to reuse the same input in the next block.
+    4. [`(Take)`](https://docs.fragcolor.xyz/blocks/General/Take/) returns the value from a sequence at a given index (starting at `0`).
+    5. `>=` saves the output of a block into a context variable.
+    6. [`(Math.Multiply)`](https://docs.fragcolor.xyz/blocks/Math/Multiply/) multiplies its input with a given value and outputs the result.
+    7. [`(Math.Add)`](https://docs.fragcolor.xyz/blocks/Math/Add/) adds a value to its input and outputs the result.
+        
     ??? note
         Because `defn` expects a single "value" after the name and the list of parameters, a `(->)` block is required to group several blocks together. As it is a common occurrence, a shortcut is also provided: `defblocks`.
 
@@ -94,19 +85,12 @@ We will render our game as a windowed application. Therefore we first need to de
 
 === "EDN"
 
-    ??? info inline end
-        We have already seen `defloop`, `defnode`, `schedule` and `run` in [step 1](./step-1.md).
-
-        `(GFX.Window)` creates the application window.
-
-        `(GUI.Window)` creates a UI window inside our application.
-
-    ```clojure linenums="1"
-    (defloop main-chain
-      (GFX.MainWindow
+    ```{.clojure .annotate linenums="1"}
+    (defloop main-chain ;; (1)
+      (GFX.MainWindow  ;; (2)
        :Title "Snake game" :Width 480 :Height 360
        :Contents
-       (-> (GUI.Window
+       (-> (GUI.Window ;; (3)
             :Title "canvas" :Width 1.0 :Height 1.0 :Pos (int2 0 0)
             :Flags [GuiWindowFlags.NoTitleBar GuiWindowFlags.MenuBar
                     GuiWindowFlags.NoResize GuiWindowFlags.NoMove GuiWindowFlags.NoCollapse]))))
@@ -115,6 +99,10 @@ We will render our game as a windowed application. Therefore we first need to de
     (schedule root main-chain)
     (run root (/ 1.0 60))
     ```
+
+    1. We have already seen `defloop`, `defnode`, `schedule` and `run` in [step 1](./step-1.md).
+    2. `(GFX.Window)` creates the application window.
+    3. `(GUI.Window)` creates a UI window inside our application.
 
 === "Result"
 

--- a/tutorials/snake/steps/step-3.md
+++ b/tutorials/snake/steps/step-3.md
@@ -33,30 +33,26 @@ To simplify the layout we will render the grid using a [`(GUI.Table)`](https://d
 
 === "EDN"
 
-    ??? info inline end
-        The input of this function will be our grid.
-
-        The [`(ForEach)`](https://docs.fragcolor.xyz/blocks/General/ForEach/) block iterates through all elements in our grid and executes an action on each one of them.
-
-        In that action, we [`(Match)`](https://docs.fragcolor.xyz/blocks/General/Match/) the value to the corresponding character we have chosen.
-
-        Then that character is displayed using [`(GUI.Text)`](https://docs.fragcolor.xyz/blocks/GUI/Text/).
-
-    ```clojure linenums="1"
-    (defblocks render []
+    ```{.clojure .annotate linenums="1"}
+    (defblocks render [] ;; (1)
       (GUI.Table
        :Columns grid-cols :Contents
-       (ForEach
+       (ForEach ;; (2)
         (-> (| (GUI.NextColumn))
-            (| (Match
+            (| (Match ;; (3)
                 [0 (-> ".") ; empty
                  1 (-> "F") ; fruit
                  2 (-> "H") ; head
                  3 (-> "B") ; body
                  4 (-> "T") ; tail
                  ]false)
-               (GUI.Text))))))
+               (GUI.Text)))))) ;; (4)
     ```
+    
+    1. The input of this function will be our grid.
+    2. The [`(ForEach)`](https://docs.fragcolor.xyz/blocks/General/ForEach/) block iterates through all elements in our grid and executes an action on each one of them.
+    3. In that action, we [`(Match)`](https://docs.fragcolor.xyz/blocks/General/Match/) the value to the corresponding character we have chosen.
+    4. Then that character is displayed using [`(GUI.Text)`](https://docs.fragcolor.xyz/blocks/GUI/Text/).
 
 ## Populating the grid
 
@@ -64,24 +60,15 @@ Before we can draw anything we need to update the grid with the fruit and the sn
 
 === "EDN"
 
-    ??? info inline end
-        We have already seen `(Take)` and `get-index` in [step 2](./step-2.md).
-
-        Assoc let us update the sequence.
-
-        [`(Slice)`](https://docs.fragcolor.xyz/blocks/General/Slice/) gives a part of a sequence in a range. `1` means we start at the second element of the sequence (in other words, we skip `1` element), and `-1` means we stop at one element before the last (in other words, we skip `1` element from the end).
-
-        [`(RTake)`](https://docs.fragcolor.xyz/blocks/General/RTake/)  is similar to [`(Take)`](https://docs.fragcolor.xyz/blocks/General/Take/) , except it starts from the end of the sequence instead of the beginning (i.e. "reverse take").
-
-    ```clojure linenums="1"
+    ```{.clojure .annotate linenums="1"}
     (defblocks populate-grid [fruit snake]
       ; saves the input into a variable
       >= .tmp-grid
 
       ; first the snake tail and body
-      snake (Take 0) (get-index) >= .tail-index
-      [.tail-index 4] (Assoc .tmp-grid)
-      snake (Slice 1 -1)
+      snake (Take 0) (get-index) >= .tail-index ;; (1)
+      [.tail-index 4] (Assoc .tmp-grid) ;; (2)
+      snake (Slice 1 -1) ;; (3)
       (ForEach
        (-> (get-index) >= .limb-index
            [.limb-index 3] (Assoc .tmp-grid)))
@@ -91,12 +78,17 @@ Before we can draw anything we need to update the grid with the fruit and the sn
       [.fruit-index 1] (Assoc .tmp-grid)
 
       ; finally the snake head
-      snake (RTake 0) (get-index) >= .head-index
+      snake (RTake 0) (get-index) >= .head-index ;; (4)
       [.head-index 2] (Assoc .tmp-grid)
 
       ; return the populated grid
       .tmp-grid)
     ```
+    
+    1. We have already seen `(Take)` and `get-index` in [step 2](./step-2.md).
+    2. Assoc lets us update the sequence.
+    3. [`(Slice)`](https://docs.fragcolor.xyz/blocks/General/Slice/) gives a part of a sequence in a range. `1` means we start at the second element of the sequence (in other words, we skip `1` element), and `-1` means we stop at one element before the last (in other words, we skip `1` element from the end).
+    4. [`(RTake)`](https://docs.fragcolor.xyz/blocks/General/RTake/)  is similar to [`(Take)`](https://docs.fragcolor.xyz/blocks/General/Take/) , except it starts from the end of the sequence instead of the beginning (i.e. "reverse take").
 
 This new function `populate-grid` will take our empty-grid as input and return a populated grid. That is why we need a temporary variable inside the function (`.tmp-grid`).
 

--- a/tutorials/snake/steps/step-4.md
+++ b/tutorials/snake/steps/step-4.md
@@ -8,35 +8,28 @@ Let's first compute the list of locations that are unoccupied.
 
 === "EDN"
 
-    ??? info inline end
-        `[]` is an empty sequence
-
-        [`(ForRange)`](https://docs.fragcolor.xyz/blocks/General/ForRange/) iterates a range of values (including both `:From` and `:To` ends).
-
-        `(- a b)` is a built-in function that can act on constant values (as opposed to [`(Math.Subtract)`](https://docs.fragcolor.xyz/blocks/Math/Subtract/) that can act on constants and variables).
-
-        [`(When)`](https://docs.fragcolor.xyz/blocks/General/When/) is similar to [`(If)`](https://docs.fragcolor.xyz/blocks/General/If/), except it is "passthrough" by default (don't worry about that concept for now).
-
-        [`(Is)`](https://docs.fragcolor.xyz/blocks/General/Is/) and [`(IsNot)`](https://docs.fragcolor.xyz/blocks/General/IsNot/) compare two values.
-
-        [`(And)`](https://docs.fragcolor.xyz/blocks/General/And/) is a logic operator.
-
-        [`(Push)`](https://docs.fragcolor.xyz/blocks/General/Push/) adds a value to a sequence.
-
-    ```clojure linenums="1"
+    ```{.clojure .annotate linenums="1"}
     (defblocks get-free-locations [snake fruit]
-      [] >= .locations
-      (ForRange
-       :From 0 :To (- grid-cols 1) :Action
+      [] >= .locations ;; (1)
+      (ForRange ;; (2)
+       :From 0 :To (- grid-cols 1) :Action ;; (3)
        (-> >= .a
            (ForRange
             :From 0 :To (- grid-rows 1) :Action
             (-> >= .b
                 [.a .b] (ToInt2) >= .location
-                (When (-> snake (IndexOf .location) (Is -1) (And) fruit (IsNot .location))
-                      (-> .location (Push .locations)))))))
+                (When (-> snake (IndexOf .location) (Is -1) (And) fruit (IsNot .location)) ;; (4) (5) (6)
+                      (-> .location (Push .locations))))))) ;; (7)
       .locations)
     ```
+
+    1. `[]` is an empty sequence.
+    2. [`(ForRange)`](https://docs.fragcolor.xyz/blocks/General/ForRange/) iterates a range of values (including both `:From` and `:To` ends).
+    3. `(- a b)` is a built-in function that can act on constant values (as opposed to [`(Math.Subtract)`](https://docs.fragcolor.xyz/blocks/Math/Subtract/) that can act on constants and variables).
+    4. [`(When)`](https://docs.fragcolor.xyz/blocks/General/When/) is similar to [`(If)`](https://docs.fragcolor.xyz/blocks/General/If/), except it is "passthrough" by default (don't worry about that concept for now).
+    5. [`(Is)`](https://docs.fragcolor.xyz/blocks/General/Is/) and [`(IsNot)`](https://docs.fragcolor.xyz/blocks/General/IsNot/) compare two values.
+    6. [`(And)`](https://docs.fragcolor.xyz/blocks/General/And/) is a logic operator.
+    7. [`(Push)`](https://docs.fragcolor.xyz/blocks/General/Push/) adds a value to a sequence.
 
 The function takes the positions of the snake body (incl. head and tail) and the current fruit position. It then iterates through all possible coordinates skipping the ones that are either occupied by the snake or the current fruit. The sequence of potential locations is then returned as the function's output.
 
@@ -44,22 +37,18 @@ Now all we need to do is select a random position from this sequence and that wi
 
 === "EDN"
 
-    ??? info inline end
-        [`(Count)`](https://docs.fragcolor.xyz/blocks/General/Count/) returns the number of elements in a sequence.
-
-        [`(RandomInt)`](https://docs.fragcolor.xyz/blocks/General/RandomInt/) returns a random value between 0 and the given maximum (exclusive).
-
-        We have already seen `(Take)` in [step 2](./step-2.md).
-
-        [`(ToInt2)`](https://docs.fragcolor.xyz/blocks/General/ToInt2/) ensures that we return an `int2` value.
-
-    ```clojure linenums="1"
+    ```{.clojure .annotate linenums="1"}
     (defblocks move-fruit [fruit snake]
       (get-free-locations fruit snake) >= .free-loc
-      (Count .free-loc) >= .max
-      (RandomInt .max) >= .next-fruit-loc
-      .free-loc (Take .next-fruit-loc) (ToInt2))
+      (Count .free-loc) >= .max ;; (1)
+      (RandomInt .max) >= .next-fruit-loc ;; (2)
+      .free-loc (Take .next-fruit-loc) (ToInt2)) ;; (3) (4)
     ```
+
+    1. [`(Count)`](https://docs.fragcolor.xyz/blocks/General/Count/) returns the number of elements in a sequence.
+    2. [`(RandomInt)`](https://docs.fragcolor.xyz/blocks/General/RandomInt/) returns a random value between 0 and the given maximum (exclusive).
+    3. We have already seen `(Take)` in [step 2](./step-2.md).
+    4. [`(ToInt2)`](https://docs.fragcolor.xyz/blocks/General/ToInt2/) ensures that we return an `int2` value.
 
 ## Moving the snake
 
@@ -69,18 +58,16 @@ When the snake is growing (after eating a fruit) we only add the new head but ke
 
 === "EDN"
 
-    ??? info inline end
-        We have already seen `(RTake)` in [step 3](./step-3.md).
-
-        [`(DropFront)`](https://docs.fragcolor.xyz/blocks/General/DropFront/) removes the first element of a sequence.
-
-        [`(WhenNot)`](https://docs.fragcolor.xyz/blocks/General/WhenNot/) is similar to [`(When)`](https://docs.fragcolor.xyz/blocks/General/When/) but with the opposite logic.
-
-    ```clojure linenums="1"
+    ```{.clojure .annotate linenums="1"}
     (defblocks move-snake [snake offset grow]
-      snake (RTake 0) (Math.Add offset) (Push snake)
-      (WhenNot (-> grow) (DropFront snake)))
+      snake (RTake 0) (Math.Add offset) (Push snake) ;; (1)
+      (WhenNot (-> grow) (DropFront snake))) ;; (2) (3)
     ```
+
+    1. We have already seen `(RTake)` in [step 3](./step-3.md).
+    2. [`(WhenNot)`](https://docs.fragcolor.xyz/blocks/General/WhenNot/) is similar to [`(When)`](https://docs.fragcolor.xyz/blocks/General/When/) but with the opposite logic.
+    3. [`(DropFront)`](https://docs.fragcolor.xyz/blocks/General/DropFront/) removes the first element of a sequence.
+
 
 Now we need the snake to move at a regular interval in the direction chosen by the player.
 
@@ -88,15 +75,14 @@ Let's first listen to the player input. We will use the keyboard's arrow keys (u
 
 === "EDN"
 
-    ??? info inline end
-        [`(Inputs.KeyDown)`](https://docs.fragcolor.xyz/blocks/Inputs/KeyDown/) executes an action when a key is down. It has a sibling event: [`(Inputs.KeyUp)`](https://docs.fragcolor.xyz/blocks/Inputs/KeyUp/).
-
-    ```clojure linenums="1"
-    (Inputs.KeyDown "up" (-> "up" > .direction))
+    ```{.clojure .annotate linenums="1"}
+    (Inputs.KeyDown "up" (-> "up" > .direction)) ;; (1)
     (Inputs.KeyDown "right" (-> "right" > .direction))
     (Inputs.KeyDown "down" (-> "down" > .direction))
     (Inputs.KeyDown "left" (-> "left" > .direction))
     ```
+
+    1. [`(Inputs.KeyDown)`](https://docs.fragcolor.xyz/blocks/Inputs/KeyDown/) executes an action when a key is down. It has a sibling event: [`(Inputs.KeyUp)`](https://docs.fragcolor.xyz/blocks/Inputs/KeyUp/).
 
 We also want to prevent the player from accidentally selecting the opposite direction (e.g. down while the snake is going up) since that would immediately end the game (as the snake would eat its own body). One easy way to do this is to compare the newly chosen direction with the previous one.
 
@@ -125,11 +111,8 @@ Finally, the snake will move at a regular interval. We can do that by comparing 
 
 === "EDN"
 
-    ??? info inline end
-        [`(Time.Now)`](https://docs.fragcolor.xyz/blocks/Time/Now/) returns the time elapsed since the start of the game.
-
-    ```clojure linenums="1"
-     (When (-> (Time.Now) (Math.Subtract .last-tick) (IsMoreEqual 0.50))
+    ```{.clojure .annotate linenums="1"}
+     (When (-> (Time.Now) (Math.Subtract .last-tick) (IsMoreEqual 0.50)) ;; (1)
            (-> (Time.Now) > .last-tick
                ; move the snake
                .direction (Match ["up" (move-snake .snake (int2 0 -1) .grow)
@@ -137,6 +120,8 @@ Finally, the snake will move at a regular interval. We can do that by comparing 
                                   "down" (move-snake .snake (int2 0 1) .grow)
                                   "left" (move-snake .snake (int2 -1 0) .grow)])))
     ```
+
+    1. [`(Time.Now)`](https://docs.fragcolor.xyz/blocks/Time/Now/) returns the time elapsed since the start of the game.
 
 Now the snake will move every half a second. We could change this value to vary the difficulty of the game.
 

--- a/tutorials/snake/steps/step-5.md
+++ b/tutorials/snake/steps/step-5.md
@@ -40,52 +40,45 @@ Now that have conditions to end the game, we can add a bit more logic to display
 
 === "EDN"
 
-    ??? info inline end
-        [`(GUI.Text)`](https://docs.fragcolor.xyz/blocks/GUI/Text/) has a few optional parameters:
-
-        - `:Format`: where `{}` is replaced by the input value.
-        - `:Color`: to use a different color.
-
-        `color` is a built-in types that represents a RGBA color, where each component is a value in the `[0, 255]` range.
-
-    ```clojure linenums="1"
+    ```{.clojure .annotate linenums="1"}
     (GUI.Window
       ; some lines omitted
       (-> .grid (render)
           (GUI.Separator)
           (When (-> .game-over)
-                (-> "GAME OVER" (GUI.Text :Color (color 255 0 0 255))
-                    (Count .snake) (GUI.Text :Format "Final score: {}")))))
+                (-> "GAME OVER" (GUI.Text :Color (color 255 0 0 255)) ;; (1)
+                    (Count .snake) (GUI.Text :Format "Final score: {}"))))) ;; (2)
     ```
+
+    1. `:Color` is an optional parameter for [`(GUI.Text)`](https://docs.fragcolor.xyz/blocks/GUI/Text/). It specifies the color of the dsiplay text using `color` (which is a built-in type that represents a RGBA color, where each component is a value in the `[0, 255]` range.)
+    2. `:Format` is an optional parameter for [`(GUI.Text)`](https://docs.fragcolor.xyz/blocks/GUI/Text/). It replaces `{}` in a given string by the input value.
 
 We will also change the background color of the game's play-space. We could change the background color of the whole window, but then the area with the **GAME OVER** text  would also share that same color. Instead, we will create a new area for the game itself. To do so we can use a child window.
 
 === "EDN"
 
-    ??? info inline end
-        [`(GUI.Style)`](https://docs.fragcolor.xyz/blocks/GUI/Style/) lets modify a UI style setting identified by the `GuiStyle` enum.
-
-    ```clojure linenums="1"
-    (color 90 165 80 255) (GUI.Style GuiStyle.ChildBgColor)
+    ```{.clojure .annotate linenums="1"}
+    (color 90 165 80 255) (GUI.Style GuiStyle.ChildBgColor) ;; (1)
     (GUI.ChildWindow :Height 240 :Contents (-> .grid (render)))
     ```
+
+    1. [`(GUI.Style)`](https://docs.fragcolor.xyz/blocks/GUI/Style/) lets you modify a UI style setting identified by the `GuiStyle` enum.
 
 We will also add a small menu, to enable the player to cleanly restart or exit the game.
 
 === "EDN"
 
-    ??? info inline end
-        [`(GUI.Menu)`](https://docs.fragcolor.xyz/blocks/GUI/Menu/) contains one or more [`(GUI.MenuItem)`](https://docs.fragcolor.xyz/blocks/GUI/MenuItem/) and is hosted in a [`(GUI.MenuBar)`](https://docs.fragcolor.xyz/blocks/GUI/MenuBar/).
-
-    ```clojure linenums="1"
+    ```{.clojure .annotate linenums="1"}
     (defblocks menus []
       (GUI.MenuBar
-       (-> (GUI.Menu
+       (-> (GUI.Menu ;; (1)
             "File" :Contents
             (-> (GUI.MenuItem "New game" :Shortcut "Space" :Action (initialize))
                 (GUI.Separator)
                 (GUI.MenuItem "Quit" :Shortcut "Alt+F4" :Action (Stop)))))))
     ```
+
+    1. [`(GUI.Menu)`](https://docs.fragcolor.xyz/blocks/GUI/Menu/) contains one or more [`(GUI.MenuItem)`](https://docs.fragcolor.xyz/blocks/GUI/MenuItem/) and is hosted in a [`(GUI.MenuBar)`](https://docs.fragcolor.xyz/blocks/GUI/MenuBar/).
 
 To display the menu we need to add the `GuiWindowFlags.MenuBar` to the sequence of flags given to the window.
 


### PR DESCRIPTION
> Modify the mkdocs.yml file to enable the code annotations feature
> Replace `Info` tabs on all Snake tutorial sample codes with corresponding code annotations