### PR TITLE
Fix glod game sample code

### DIFF
--- a/tutorials/glod-game/full-game/glodgame.edn
+++ b/tutorials/glod-game/full-game/glodgame.edn
@@ -294,7 +294,7 @@
   0.0 > spikeball-y
   0.0 > spikeball-velocity
   (float2 spikeball-x spikeball-y) > spikeball-position
-  .spikeball-x-1
+  
   (Pause pausefloat))
 
 (defloop spikeball-1

--- a/tutorials/glod-game/steps/step-3.md
+++ b/tutorials/glod-game/steps/step-3.md
@@ -1225,7 +1225,7 @@ When you run the programme, Glod will  return to his idle animation whenever you
     (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
     ```
 
-    > Add in a jumping right image and rename our original **.character-jumping** to **.character-jumping-left** added to line 5 - 7.
+    > Add in a jumping right image and rename our original **.character-jumping** to **.character-jumping-left**. Code added to lines 6-8. Remove the other images that are now not being used anymore.
 
     ```{.clojure .annotate linenums="1"}
     (Match [0 (-> .character-direction
@@ -1241,7 +1241,7 @@ When you run the programme, Glod will  return to his idle animation whenever you
             :Passthrough false)
     ```
 
-    > Then add another **Match** to our original **Match** to show the corresponding jump image depending on Glod's direction.Code added to lines 127-137.
+    > Then add another **Match** to our original **Match** to show the corresponding jump image depending on Glod's direction. Code added to lines 144-148.
 
 === "Full Code So Far"
     
@@ -1251,10 +1251,9 @@ When you run the programme, Glod will  return to his idle animation whenever you
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ----------
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -1390,7 +1389,10 @@ When you run the programme, Glod will  return to his idle animation whenever you
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2)))
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))]
+                                  :Passthrough false))]
                    :Passthrough false)))))
 
         (GFX.Render :Steps .render-steps)

--- a/tutorials/glod-game/steps/step-4.md
+++ b/tutorials/glod-game/steps/step-4.md
@@ -29,7 +29,7 @@ Create the `.x` and `.y` variables which will be used to create the variable `.c
     (float2 .x .y) >= .character-position
     ```
 
-    1. Added under `initialize-character`, at line 14.
+    1. Added to line 13 under `initialize-character`.
 
 `.character-position` is then fed into the `Position` parameter of the `UI.Area` shard. When the `.x` and `.y` values are changed, the `UI.Area` will move and hence move our character.
 
@@ -38,12 +38,12 @@ Remember to change the `Anchor` to `Anchor.Top`!
 === "Code Added"
     ```{.clojure .annotate linenums="1"}
     (UI.Area
-     :Position .character-position ;; (1)
-     :Anchor Anchor.Top
+     :Position .character-position 
+     :Anchor Anchor.Top ;; (1)
      :Contents
     ```
     
-    1. Code edited at line 138.
+    1. Code edited at line 152.
 
 === "Full Code So Far"
     
@@ -53,10 +53,9 @@ Remember to change the `Anchor` to `Anchor.Top`!
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ----------
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -196,7 +195,10 @@ Remember to change the `Anchor` to `Anchor.Top`!
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2)))
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))]
+                                  :Passthrough false))]
                    :Passthrough false)))))
 
         (GFX.Render :Steps .render-steps)
@@ -222,7 +224,7 @@ First, create a new variable named `.character-x-velocity`. We will change this 
     0.0 >= .character-x-velocity ;; (1)
     ```
 
-    1. Added to `initialize-character` at line 17.
+    1. Added to line 16 under `initialize-character`.
 
 Create the `run-logic` shard. When `.character-x-velocity` is changed, it will be added to `.x` and `.character-position` will be updated accordingly.
 
@@ -237,7 +239,7 @@ Create the `run-logic` shard. When `.character-x-velocity` is changed, it will b
       (float2 .x .y) > .character-position)
     ```
 
-    1. Added to line 83.
+    1. Added to line 81.
 
  Update the value of `.character-x-velocity` whenever the left or right directional buttons are pressed. Remember to reset the value back to 0 when the buttons are released. If not, Glod will move to the left or right forever.
 
@@ -286,13 +288,13 @@ Create the `run-logic` shard. When `.character-x-velocity` is changed, it will b
         0.0 > .character-x-velocity)))
     ```
 
-    1. Updated within the `button-inputs` shard at line 90.
+    1. Updated within the `button-inputs` shard at line 89.
 
     ```{.clojure .annotate linenums="1"}
     (run-logic) ;; (1)
     ```
 
-    1. `run-logic` is added to the `main-wire` at line 134.
+    1. `run-logic` is added to the `main-wire` at line 133.
 
 === "Full Code So Far"
     
@@ -302,10 +304,9 @@ Create the `run-logic` shard. When `.character-x-velocity` is changed, it will b
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ---------- 
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -459,7 +460,10 @@ Create the `run-logic` shard. When `.character-x-velocity` is changed, it will b
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2)))
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))]
+                                  :Passthrough false))]
                    :Passthrough false)))))
 
         (GFX.Render :Steps .render-steps)
@@ -487,7 +491,7 @@ Let's set up a boundary to ensure that Glod does not fall off the edge and into 
       var (Max min) (Min max) > var)
     ```
 
-  1. Added to line 82.
+  1. Added to line 81.
 
 This clamp function takes in a value and makes sure that it does not exceed the minimum and maximum values.
 
@@ -502,7 +506,7 @@ Call our `clamp` function in `run-logic` and set the `var` parameter to be `.x`,
     (clamp .x -600.0 600.0) ;; (1)
     ```
 
-    1. Added to line 93.
+    1. Added to line 92.
 
 === "Full Code So Far"
     
@@ -512,10 +516,9 @@ Call our `clamp` function in `run-logic` and set the `var` parameter to be `.x`,
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ----------
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -675,7 +678,10 @@ Call our `clamp` function in `run-logic` and set the `var` parameter to be `.x`,
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction 
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2))) 
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))] 
+                                  :Passthrough false))]
                    :Passthrough false)))))
 
         (GFX.Render :Steps .render-steps)
@@ -709,7 +715,7 @@ First, create the variables that we will use.
     0.0 >= .character-y-acceleration
     ```
 
-    1. Added to lines 18 and 19.
+    1. Added to lines 17 and 18.
 
 Similar to `run-logic`, we will add `.character-y-velocity` to our `.y` variable. This time however, we will also add .`character-y-acceleration` to `.character-y-velocity`.
 
@@ -726,13 +732,13 @@ Similar to `run-logic`, we will add `.character-y-velocity` to our `.y` variable
       (float2 .x .y) > .character-position)
     ```
 
-    1. Added to line 98.
+    1. Added to line 97.
 
     ```{.clojure .annotate linenums="1"}
     (gravity-logic) ;; (1)
     ```
 
-    1. Added to line 160 in `main-wire`.
+    1. Added to line 154 in `main-wire`.
 
 Lastly we modify the value of `.character-y-velocity` and `.character-y-acceleration` whenever the Up directional button is pressed.
 
@@ -746,7 +752,7 @@ Lastly we modify the value of `.character-y-velocity` and `.character-y-accelera
                 -20.0 > .character-y-velocity ;; (1)
                 1.0 >  .character-y-acceleration))
     ```
-    1. Added to line 140 in `button-inputs`.
+    1. Added to line 132 in `button-inputs`.
 
 === "Full Code So Far"
     
@@ -756,10 +762,9 @@ Lastly we modify the value of `.character-y-velocity` and `.character-y-accelera
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ---------- 
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -934,7 +939,10 @@ Lastly we modify the value of `.character-y-velocity` and `.character-y-accelera
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction 
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2))) 
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))] 
+                                  :Passthrough false))]
                    :Passthrough false)))))
 
         (GFX.Render :Steps .render-steps)
@@ -973,7 +981,7 @@ First, call our `clamp` function in `gravity-logic` with `.y` as our `var`, -620
     (clamp .y -620.0 620.0) ;; (1)
     ```
 
-    1. Added to lines 107.
+    1. Added to lines 106.
 
 Next, add a conditional statement to ensure that our y velocity and acceleration reverts back to 0 when Glod is on the ground.
 
@@ -988,7 +996,7 @@ Next, add a conditional statement to ensure that our y velocity and acceleration
               0.0 > .character-y-acceleration))
     ```
 
-    1. Added to line 108.
+    1. Added to line 107.
 
 === "Full Code So Far"
     
@@ -998,10 +1006,9 @@ Next, add a conditional statement to ensure that our y velocity and acceleration
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ---------- 
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -1184,7 +1191,10 @@ Next, add a conditional statement to ensure that our y velocity and acceleration
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction 
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2))) 
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))] 
+                                  :Passthrough false))]
                    :Passthrough false)))))
 
         (GFX.Render :Steps .render-steps)
@@ -1230,7 +1240,7 @@ In `gravity-logic`, revert `character-state` to 0 when the character is jumping.
                           0 > .character-state))))
     ```
 
-    1. Added to line 114, under `gravity-logic`.
+    1. Added to line 113, under `gravity-logic`.
 
 === "Full Code So Far"
     
@@ -1240,10 +1250,9 @@ In `gravity-logic`, revert `character-state` to 0 when the character is jumping.
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ---------- 
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -1431,7 +1440,10 @@ In `gravity-logic`, revert `character-state` to 0 when the character is jumping.
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction 
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2))) 
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))] 
+                                  :Passthrough false))]
                    :Passthrough false)))))
 
         (GFX.Render :Steps .render-steps)
@@ -1480,7 +1492,7 @@ The second problem is also an easy fix. We simply put a `When` conditional state
       5.0 > .character-x-velocity))
     ```
 
-    1. Edited from line 127 onwards.
+    1. Edited from line 126 onwards.
 
 === "Full Code So Far"
     
@@ -1490,10 +1502,9 @@ The second problem is also an easy fix. We simply put a `When` conditional state
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ---------- 
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -1687,7 +1698,10 @@ The second problem is also an easy fix. We simply put a `When` conditional state
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction 
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2))) 
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))] 
+                                  :Passthrough false))]
                    :Passthrough false)))))
 
         (GFX.Render :Steps .render-steps)
@@ -1709,7 +1723,7 @@ First, create a `.can-jump` variable under `initialize-character`.
     true >= .can-jump ;; (1)
     ```
 
-    1. Added to line 13.
+    1. Added to line 12.
 
 Set it such that Glod cannot jump again when he is jumping. When the jump button is pressed, `.can-jump` becomes false.
 
@@ -1754,7 +1768,7 @@ Lastly we reset `.can-jump` back to true when Glod touches the floor again.
                         0 > .character-state))))
     ```
 
-    1. Edited from line 115 onwards.
+    1. Edited from line 114 onwards.
 
 === "Full Code So Far"
     
@@ -1764,10 +1778,9 @@ Lastly we reset `.can-jump` back to true when Glod touches the floor again.
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ----------
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -1968,7 +1981,10 @@ Lastly we reset `.can-jump` back to true when Glod touches the floor again.
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2)))
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))]
+                                  :Passthrough false))]
                    :Passthrough false)))))
 
         (GFX.Render :Steps .render-steps)

--- a/tutorials/glod-game/steps/step-5.md
+++ b/tutorials/glod-game/steps/step-5.md
@@ -40,7 +40,7 @@ Create a new `initialize-coin` shard. We will separate the initializing of our c
       (LoadTexture "GlodImages/Coin/Coin_1.png") = .coin-1)
     ```
 
-    1. Added to line 177.
+    1. Added to line 176.
 
 Remember to call `initialize-coin` in the `Setup` of the `main-wire`to ensure that these variables are only created once.
 
@@ -53,7 +53,7 @@ Remember to call `initialize-coin` in the `Setup` of the `main-wire`to ensure th
        (initialize-coin)) ;; (1)
     ```
 
-    1. Added to line 183.
+    1. Added to line 182.
 
 We then create a new `UI.Area` to draw the coin on the screen.
 
@@ -66,7 +66,7 @@ We then create a new `UI.Area` to draw the coin on the screen.
      :Contents (-> .coin-1 (UI.Image :Scale (float2 0.2)))
     ```
 
-    1. Added to line 218.
+    1. Added to line 220.
 
 === "Full Code So Far"
     
@@ -76,10 +76,9 @@ We then create a new `UI.Area` to draw the coin on the screen.
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ----------
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -285,7 +284,10 @@ We then create a new `UI.Area` to draw the coin on the screen.
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2)))
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))]
+                                  :Passthrough false))]
                    :Passthrough false)))
 
           (UI.Area
@@ -326,6 +328,7 @@ We also create variables for controlling the Coin animation:
 
 === "Code Added"
     
+    ```{.clojure .annotate linenums="1"}
     ;; -------------- Initialize Coin ----------
     (defshards initialize-coin [] ;; (1)
       (LoadTexture "GlodImages/Coin/Coin_1.png") >> .coin-image-array
@@ -338,37 +341,43 @@ We also create variables for controlling the Coin animation:
       (Count .coin-image-array) (Math.Subtract 1) >= .coin-image-index-max
       0 >= .coin-image-index
       0.1 >= .coin-animation-speed)
+    ```
 
-    1. Updated `initialize-coin` at line 177.
+    1. Updated `initialize-coin` at line 176.
 
 Then we create a `coin-animation` loop that follows the same logic as Glod's animations.
 
 === "Code Added"
 
+    ```{.clojure .annotate linenums="1"}
     ;; -------------- Coin Animation ------------------
-    (defloop coin-animation
+    (defloop coin-animation ;; (1)
       .coin-image-index (Math.Add 1)
-      > .coin-image-index
+      .coin-image-index
       (When
        :Predicate (IsMore .coin-image-index-max)
        :Action (-> 0 > .coin-image-index))
 
       (Pause .coin-animation-speed)) 
+    ```
 
-    1. Added to line 190.
+    1. Added to line 189.
 
 Remember to `Step` into the Coin's animation in your `main-wire`!
 
 === "Code Added"
 
+    ```{.clojure .annotate linenums="1"}
     (Step coin-animation) ;; (1)
+    ```
 
-    1. Added to line 210.
+    1. Added to line 209.
 
 Lastly, update your coin's `UI.Area` to draw the image located in an index of `.coin-image-array`. The index used is determined by the value of `.coin-image-index`.
 
 === "Code Added"
 
+    ```{.clojure .annotate linenums="1"}
     (UI.Area
      :Position (float2 0 0)
      :Anchor Anchor.Top
@@ -376,20 +385,21 @@ Lastly, update your coin's `UI.Area` to draw the image located in an index of `.
      (-> .coin-image-array
          (Take .coin-image-index)
          (UI.Image :Scale (float2 0.2))))
+    ```
 
-    1. Added to line 239.
+    1. Added to line 241.
 
 === "Full Code So Far"
 
+    ```{.clojure .annotate linenums="1"}
     (defshards load-texture [name]
       (LoadImage name)
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ----------
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -616,7 +626,10 @@ Lastly, update your coin's `UI.Area` to draw the image located in an index of `.
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2)))
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))]
+                                  :Passthrough false))]
                    :Passthrough false)))
 
           (UI.Area
@@ -634,6 +647,7 @@ Lastly, update your coin's `UI.Area` to draw the image located in an index of `.
     (defmesh main)
     (schedule main main-wire)
     (run main (/ 1.0 60))
+    ```
 
 Try running your code to see if your coin is animated. Good job if it is!
 
@@ -658,7 +672,7 @@ First we create the coin's x, y, and position variables.
     (float2 .coinx-1 .coiny-1) >= .coin-position-1
     ```
 
-    1. Added to line 190.
+    1. Added to line 189.
 
 We then replace the value of the `Position` parameter in our coin's `UI.Area`.
 
@@ -674,7 +688,7 @@ We then replace the value of the `Position` parameter in our coin's `UI.Area`.
          (UI.Image :Scale (float2 0.2))))
     ```
 
-    1. Amended at line 245.
+    1. Amended at line 247.
 
 
 === "Full Code So Far"
@@ -685,10 +699,9 @@ We then replace the value of the `Position` parameter in our coin's `UI.Area`.
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ----------
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -920,7 +933,10 @@ We then replace the value of the `Position` parameter in our coin's `UI.Area`.
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2)))
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))]
+                                  :Passthrough false))]
                    :Passthrough false)))
 
           (UI.Area
@@ -953,7 +969,7 @@ First, create velocity and acceleration variables under the `initialize-coin` sh
     0.5 >= .coin-acceleration
     ```
 
-    1. Added to line 188, under `initialize-coin`.
+    1. Added to line 187, under `initialize-coin`.
 
 Create our `coin-gravity-logic` shard. The logic behind it is the same as our jump logic. We add velocity to the y position and then add acceleration to our velocity to increase the rate of increase.
 
@@ -972,7 +988,7 @@ Create our `coin-gravity-logic` shard. The logic behind it is the same as our ju
       (float2 .coinx-1 .coiny-1) > .coin-position-1)
     ```
 
-    1. Added to line 207.
+    1. Added to line 206.
 
 Remember to call the `coin-gravity-logic` shard in our `main-wire` loop.
 
@@ -982,7 +998,7 @@ Remember to call the `coin-gravity-logic` shard in our `main-wire` loop.
     (coin-gravity-logic) ;; (1)
     ```
 
-    1. Added to line 229.
+    1. Added to line 228.
 
 === "Full Code So Far"
     
@@ -992,10 +1008,9 @@ Remember to call the `coin-gravity-logic` shard in our `main-wire` loop.
       (GFX.Texture))
 
     (defshards initialize-character []
-      (LoadTexture "GlodImages/Character1.png") = .idle-left-image-array
-      (LoadTexture "GlodImages/Character1_Left.png") = .character-left
-      (LoadTexture "GlodImages/Character1_Right.png") = .character-right
-      (LoadTexture "GlodImages/Character1_Jumping.png") = .character-jumping
+      ;; -------------- Character Jumping  ---------- 
+      (LoadTexture "GlodImages/Character1_Jumping_Left.png") = .character-jumping-left
+      (LoadTexture "GlodImages/Character1_Jumping_Right.png") = .character-jumping-right
 
       0 >= .character-state
       0 >= .character-direction ;; 0 = facing left, 1 = facing right
@@ -1241,7 +1256,10 @@ Remember to call the `coin-gravity-logic` shard in our `main-wire` loop.
                                  :Passthrough false))
                     1 (-> .walking-left-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
                     2 (-> .walking-right-image-array (Take .walking-image-index) (UI.Image :Scale (float2 0.2)))
-                    3 (-> .character-jumping (UI.Image :Scale (float2 0.2)))]
+                    3 (->  .character-direction
+                          (Match [0 (-> .character-jumping-left (UI.Image :Scale (float2 0.2)))
+                                  1 (-> .character-jumping-right (UI.Image :Scale (float2 0.2)))]
+                                  :Passthrough false))]
                    :Passthrough false)))
 
           (UI.Area

--- a/tutorials/glod-game/steps/step-6.md
+++ b/tutorials/glod-game/steps/step-6.md
@@ -1428,7 +1428,7 @@ This time however, we will have different randomized x values and have this happ
       0.0 > spikeball-y
       0.0 > spikeball-velocity
       (float2 spikeball-x spikeball-y) > spikeball-position
-      .spikeball-x-1
+      
       (Pause pausefloat))
     ```
 
@@ -1737,7 +1737,7 @@ Call your `spikeball-1` loop in the `main-wire`.
       0.0 > spikeball-y
       0.0 > spikeball-velocity
       (float2 spikeball-x spikeball-y) > spikeball-position
-      .spikeball-x-1
+
       (Pause pausefloat))
 
     (defloop spikeball-1
@@ -2260,7 +2260,7 @@ Create the logic to dictate what happens when our spiked cannonball hits Glod. R
       0.0 > spikeball-y
       0.0 > spikeball-velocity
       (float2 spikeball-x spikeball-y) > spikeball-position
-      .spikeball-x-1
+
       (Pause pausefloat))
 
     (defloop spikeball-1
@@ -2844,7 +2844,7 @@ All we have to do is to follow these easy steps:
       0.0 > spikeball-y
       0.0 > spikeball-velocity
       (float2 spikeball-x spikeball-y) > spikeball-position
-      .spikeball-x-1
+      
       (Pause pausefloat))
 
     (defloop spikeball-1

--- a/tutorials/glod-game/steps/step-7.md
+++ b/tutorials/glod-game/steps/step-7.md
@@ -441,7 +441,7 @@ Lastly, remember to call your shard and loop in your `main-wire`.
       0.0 > spikeball-y
       0.0 > spikeball-velocity
       (float2 spikeball-x spikeball-y) > spikeball-position
-      .spikeball-x-1
+      
       (Pause pausefloat))
 
     (defloop spikeball-1
@@ -1099,7 +1099,7 @@ Create our logic to loop our damage effect animation which plays when `.damage-e
       0.0 > spikeball-y
       0.0 > spikeball-velocity
       (float2 spikeball-x spikeball-y) > spikeball-position
-      .spikeball-x-1
+      
       (Pause pausefloat))
 
     (defloop spikeball-1
@@ -1757,7 +1757,7 @@ Remember to add this `UI.Area` before the `UI.Area` which houses your character 
       0.0 > spikeball-y
       0.0 > spikeball-velocity
       (float2 spikeball-x spikeball-y) > spikeball-position
-      .spikeball-x-1
+      
       (Pause pausefloat))
 
     (defloop spikeball-1
@@ -2464,7 +2464,7 @@ Remember to call and `Step` them in the `main-wire`.
       0.0 > spikeball-y
       0.0 > spikeball-velocity
       (float2 spikeball-x spikeball-y) > spikeball-position
-      .spikeball-x-1
+      
       (Pause pausefloat))
 
     (defloop spikeball-1
@@ -3262,7 +3262,7 @@ Finally its time to code the final bit for our game. We need to add some finalit
       0.0 > spikeball-y
       0.0 > spikeball-velocity
       (float2 spikeball-x spikeball-y) > spikeball-position
-      .spikeball-x-1
+      
       (Pause pausefloat))
 
     (defloop spikeball-1


### PR DESCRIPTION
Added in the correct import statements and `Match` for character jumping images from step 3.6 to step 5.3.
Removed the redundant variable in step 6, step 7, and the full code.